### PR TITLE
update to version 7.900.1

### DIFF
--- a/recipe/CMakeLists.patch
+++ b/recipe/CMakeLists.patch
@@ -1,31 +1,32 @@
---- CMakeLists.txt	2016-06-16 12:16:15.000000000 -0400
-+++ CMakeLists_New.txt	2017-03-05 01:11:29.000000000 -0500
-@@ -104,11 +104,20 @@
+--- CMakeLists.txt	2016-06-16 12:16:21.000000000 -0400
++++ CMakeLists_New.txt	2017-05-19 13:03:31.591245700 -0400
+@@ -145,12 +145,21 @@
    
    set(ARMA_OS macos)
    
 -  set(ARMA_USE_LAPACK true)
 -  set(ARMA_USE_BLAS   true)
-+#  set(ARMA_USE_LAPACK true)
-+#  set(ARMA_USE_BLAS   true)
++  # set(ARMA_USE_LAPACK true)
++  # set(ARMA_USE_BLAS   true)
    
 -  set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
 -  message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
-+#  set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
-+#  message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
-+
-+   include(ARMA_FindOpenBLAS)
-+   message(STATUS "OpenBLAS_FOUND = ${OpenBLAS_FOUND}")
-+ 
-+   if(OpenBLAS_FOUND)
-+     set(ARMA_USE_BLAS true)
-+     set(ARMA_USE_LAPACK true)  # OpenBLAS includes LAPACK in same library
-+     set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})
-+   endif()
++  # set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
++  # message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
    
++  include(ARMA_FindOpenBLAS)
++  message(STATUS "OpenBLAS_FOUND = ${OpenBLAS_FOUND}")
++ 
++  if(OpenBLAS_FOUND)
++    set(ARMA_USE_BLAS true)
++    set(ARMA_USE_LAPACK true)  # OpenBLAS includes LAPACK in same library
++    set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})
++  endif()
++
    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-@@ -195,6 +204,7 @@
+     message(STATUS "Clang compiler on MacOS X detected. Added '-stdlib=libc++' to compiler flags")
+@@ -236,6 +245,7 @@
      if(OpenBLAS_FOUND)
        
        set(ARMA_USE_BLAS true)
@@ -33,17 +34,15 @@
        set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})
        
        message(STATUS "")
-@@ -219,14 +229,14 @@
-         set(ARMA_USE_BLAS true)
+@@ -261,13 +271,13 @@
          set(ARMA_LIBS ${ARMA_LIBS} ${BLAS_LIBRARIES})
        endif()
--      
-+ 
+       
 +      if(LAPACK_FOUND)
 +        set(ARMA_USE_LAPACK true)
 +        set(ARMA_LIBS ${ARMA_LIBS} ${LAPACK_LIBRARIES})
 +      endif()
-+     
++      
      endif()
      
 -    if(LAPACK_FOUND)
@@ -54,3 +53,11 @@
    endif()
    
  endif()
+@@ -275,7 +285,6 @@
+ 
+ find_package(PkgConfig)
+ 
+-
+ # set(DETECT_HDF5 true)
+ 
+ ## uncomment the above line to enable the detection of the HDF5 library;

--- a/recipe/make_tests.patch
+++ b/recipe/make_tests.patch
@@ -1,5 +1,5 @@
---- tests/Makefile	2017-02-11 20:49:48.000000000 -0500
-+++ tests/Makefile_new	2017-02-11 21:06:53.000000000 -0500
+--- Makefile	2016-06-16 12:16:21.000000000 -0400
++++ Makefile_new	2017-05-19 13:20:16.455240000 -0400
 @@ -1,9 +1,9 @@
  
 -LIB_FLAGS = -larmadillo
@@ -9,6 +9,6 @@
  
 -CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0
 +CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -I${PREFIX}/include
+ #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -fopenmp
  #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -DARMA_DONT_USE_WRAPPER
  #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O2
- 

--- a/recipe/make_tests.patch
+++ b/recipe/make_tests.patch
@@ -1,12 +1,12 @@
---- Makefile	2016-06-16 12:16:21.000000000 -0400
-+++ Makefile_new	2017-05-19 13:20:16.455240000 -0400
+--- tests/Makefile	2016-06-16 12:16:21.000000000 -0400
++++ tests/Makefile_new	2017-05-19 13:20:16.455240000 -0400
 @@ -1,9 +1,9 @@
- 
+
 -LIB_FLAGS = -larmadillo
 +LIB_FLAGS = -larmadillo -L${PREFIX}/lib
- #LIB_FLAGS = -lblas -llapack 
- #LIB_FLAGS = -lopenblas -llapack 
- 
+ #LIB_FLAGS = -lblas -llapack
+ #LIB_FLAGS = -lopenblas -llapack
+
 -CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0
 +CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -I${PREFIX}/include
  #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -fopenmp

--- a/recipe/make_tests_osx.patch
+++ b/recipe/make_tests_osx.patch
@@ -1,5 +1,5 @@
---- tests/Makefile	2017-02-11 20:49:48.000000000 -0500
-+++ tests/Makefile_new	2017-02-11 21:23:15.000000000 -0500
+--- Makefile	2016-06-16 12:16:21.000000000 -0400
++++ Makefile_new	2017-05-19 13:21:22.295297500 -0400
 @@ -1,9 +1,9 @@
  
 -LIB_FLAGS = -larmadillo
@@ -9,6 +9,6 @@
  
 -CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0
 +CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -I${PREFIX}/include -stdlib=libc++
+ #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -fopenmp
  #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -DARMA_DONT_USE_WRAPPER
  #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O2
- 

--- a/recipe/make_tests_osx.patch
+++ b/recipe/make_tests_osx.patch
@@ -1,12 +1,12 @@
---- Makefile	2016-06-16 12:16:21.000000000 -0400
-+++ Makefile_new	2017-05-19 13:21:22.295297500 -0400
+--- tests/Makefile	2016-06-16 12:16:21.000000000 -0400
++++ tests/Makefile_new	2017-05-19 13:21:22.295297500 -0400
 @@ -1,9 +1,9 @@
- 
+
 -LIB_FLAGS = -larmadillo
 +LIB_FLAGS = -larmadillo -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib
- #LIB_FLAGS = -lblas -llapack 
- #LIB_FLAGS = -lopenblas -llapack 
- 
+ #LIB_FLAGS = -lblas -llapack
+ #LIB_FLAGS = -lopenblas -llapack
+
 -CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0
 +CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -I${PREFIX}/include -stdlib=libc++
  #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -fopenmp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.800.1" %}
+{% set version = "7.900.1" %}
 {% set variant = "openblas" %}
 
 package:
@@ -8,12 +8,12 @@ package:
 source:
     fn: armadillo-{{ version }}.tar.xz
     url: http://sourceforge.net/projects/arma/files/armadillo-{{ version }}.tar.xz
-    sha256: 5ada65a5a610301ae188bb34f0ac6e7fdafbdbcd0450b0adb7715349ae14b8db
+    sha256: 33eec7013990b5477ccc5ad3abc68bc2326c7a7a2790014d625cfcf37c0e07d3
     patches:
         # have to add additional ${PREFIX}/lib etc... to tests/Makefile
         - make_tests.patch  # [linux]
         - make_tests_osx.patch  # [osx]
-        # modify CMakeLists to use OpenBLAS rather than Accelrate on OS X
+        # modify CMakeLists to use OpenBLAS rather than Accelerate on OS X
         # and to use OpenBLAS as the LAPACK library on linux
         - CMakeLists.patch
 


### PR DESCRIPTION
One new feature in 7.900 is support for OpenMP.  I have not modified the recipe to support this here.

from their docs

>Armadillo can use OpenMP to automatically speed up computationally
expensive element-wise functions such as exp(), log(), cos(), etc.
This requires a C++11/C++14 compiler with OpenMP 3.0+ support.
>
>When using gcc or clang, use the following options to enable both
C++11 and OpenMP:  -std=c++11 -fopenmp
>
>Caveat: when using gcc, use of -march=native in conjunction with -fopenmp
may lead to speed regressions on recent processors.

