### PR TITLE
Updates the feedstock to version 7.950

### DIFF
--- a/recipe/CMakeLists.patch
+++ b/recipe/CMakeLists.patch
@@ -1,16 +1,26 @@
---- CMakeLists.txt	2016-06-16 18:16:30.000000000 +0200
-+++ CMakeLists_new.txt	2017-06-11 13:33:26.000000000 +0200
-@@ -148,9 +148,23 @@
+--- CMakeLists.txt	2016-06-16 18:16:31.000000000 +0200
++++ CMakeLists_new.txt	2017-06-28 19:30:47.000000000 +0200
+@@ -142,15 +142,30 @@
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake_aux/Modules/")
+ 
+ if(APPLE)
+-  
++
+   set(ARMA_OS macos)
+-  
++
    set(ARMA_USE_LAPACK true)
    set(ARMA_USE_BLAS   true)
-   
+-  
 -  set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
 -  message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
 -  
++
++  include(ARMA_FindLAPACK)
 +  include(ARMA_FindOpenBLAS)
 +
-+  if(OpenBLAS_FOUND)      
-+    set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})    
++  if(OpenBLAS_FOUND)
++    set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})
 +    set(ARMA_LIBS ${ARMA_LIBS} ${LAPACK_LIBRARIES})
 +    message(STATUS "")
 +    message(STATUS "*** If the OpenBLAS library is installed in")
@@ -18,8 +28,8 @@
 +    message(STATUS "*** make sure the run-time linker can find it.")
 +    message(STATUS "*** On Linux systems this can be done by editing /etc/ld.so.conf")
 +    message(STATUS "*** or modifying the LD_LIBRARY_PATH environment variable.")
-+    message(STATUS "")      
-+  else()        
++    message(STATUS "")
++  else()
 +    set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
 +    message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
 +  endif()

--- a/recipe/CMakeLists.patch
+++ b/recipe/CMakeLists.patch
@@ -1,56 +1,29 @@
---- CMakeLists.txt	2016-06-16 12:16:15.000000000 -0400
-+++ CMakeLists_New.txt	2017-03-05 01:11:29.000000000 -0500
-@@ -104,11 +104,20 @@
-   
-   set(ARMA_OS macos)
-   
--  set(ARMA_USE_LAPACK true)
--  set(ARMA_USE_BLAS   true)
-+#  set(ARMA_USE_LAPACK true)
-+#  set(ARMA_USE_BLAS   true)
+--- CMakeLists.txt	2016-06-16 18:16:30.000000000 +0200
++++ CMakeLists_new.txt	2017-06-11 13:33:26.000000000 +0200
+@@ -148,9 +148,23 @@
+   set(ARMA_USE_LAPACK true)
+   set(ARMA_USE_BLAS   true)
    
 -  set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
 -  message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
-+#  set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
-+#  message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
+-  
++  include(ARMA_FindOpenBLAS)
 +
-+   include(ARMA_FindOpenBLAS)
-+   message(STATUS "OpenBLAS_FOUND = ${OpenBLAS_FOUND}")
-+ 
-+   if(OpenBLAS_FOUND)
-+     set(ARMA_USE_BLAS true)
-+     set(ARMA_USE_LAPACK true)  # OpenBLAS includes LAPACK in same library
-+     set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})
-+   endif()
-   
++  if(OpenBLAS_FOUND)      
++    set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})    
++    set(ARMA_LIBS ${ARMA_LIBS} ${LAPACK_LIBRARIES})
++    message(STATUS "")
++    message(STATUS "*** If the OpenBLAS library is installed in")
++    message(STATUS "*** /usr/local/lib or /usr/local/lib64")
++    message(STATUS "*** make sure the run-time linker can find it.")
++    message(STATUS "*** On Linux systems this can be done by editing /etc/ld.so.conf")
++    message(STATUS "*** or modifying the LD_LIBRARY_PATH environment variable.")
++    message(STATUS "")      
++  else()        
++    set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
++    message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
++  endif()
++    
    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-@@ -195,6 +204,7 @@
-     if(OpenBLAS_FOUND)
-       
-       set(ARMA_USE_BLAS true)
-+      set(ARMA_USE_LAPACK true)
-       set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})
-       
-       message(STATUS "")
-@@ -219,14 +229,14 @@
-         set(ARMA_USE_BLAS true)
-         set(ARMA_LIBS ${ARMA_LIBS} ${BLAS_LIBRARIES})
-       endif()
--      
-+ 
-+      if(LAPACK_FOUND)
-+        set(ARMA_USE_LAPACK true)
-+        set(ARMA_LIBS ${ARMA_LIBS} ${LAPACK_LIBRARIES})
-+      endif()
-+     
-     endif()
-     
--    if(LAPACK_FOUND)
--      set(ARMA_USE_LAPACK true)
--      set(ARMA_LIBS ${ARMA_LIBS} ${LAPACK_LIBRARIES})
--    endif()
--      
-   endif()
-   
- endif()
+     message(STATUS "Clang compiler on MacOS X detected. Added '-stdlib=libc++' to compiler flags")

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,7 +14,8 @@ if [[ `uname` == 'Darwin' ]]; then
 else
 
     cmake .. \
-        -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+        -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+        -DCMAKE_INSTALL_LIBDIR="lib"
     #    -DDETECT_HDF5="true"
 fi
 

--- a/recipe/make_tests.patch
+++ b/recipe/make_tests.patch
@@ -1,14 +1,16 @@
---- tests/Makefile	2017-02-11 20:49:48.000000000 -0500
-+++ tests/Makefile_new	2017-02-11 21:06:53.000000000 -0500
+--- tests/Makefile	2017-06-10 23:07:42.000000000 +0200
++++ tests/Makefile_new	2017-06-11 15:48:43.000000000 +0200
 @@ -1,9 +1,9 @@
  
 -LIB_FLAGS = -larmadillo
+-#LIB_FLAGS = -lblas -llapack 
+-#LIB_FLAGS = -lopenblas -llapack 
 +LIB_FLAGS = -larmadillo -L${PREFIX}/lib
- #LIB_FLAGS = -lblas -llapack 
- #LIB_FLAGS = -lopenblas -llapack 
++#LIB_FLAGS = -lblas -llapack
++#LIB_FLAGS = -lopenblas -llapack
  
 -CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0
 +CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -I${PREFIX}/include
+ #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -fopenmp
  #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -DARMA_DONT_USE_WRAPPER
  #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O2
- 

--- a/recipe/make_tests_osx.patch
+++ b/recipe/make_tests_osx.patch
@@ -1,5 +1,5 @@
---- tests/Makefile	2017-02-11 20:49:48.000000000 -0500
-+++ tests/Makefile_new	2017-02-11 21:23:15.000000000 -0500
+--- tests/Makefile	2017-06-10 23:07:42.000000000 +0200
++++ tests/Makefile_new	2017-06-10 23:24:44.000000000 +0200
 @@ -1,9 +1,9 @@
  
 -LIB_FLAGS = -larmadillo
@@ -9,6 +9,6 @@
  
 -CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0
 +CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -I${PREFIX}/include -stdlib=libc++
+ #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -fopenmp
  #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -DARMA_DONT_USE_WRAPPER
  #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O2
- 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.950.0" %}
+{% set version = "7.950.1" %}
 {% set variant = "openblas" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
     fn: armadillo-{{ version }}.tar.xz
     url: http://sourceforge.net/projects/arma/files/armadillo-{{ version }}.tar.xz
-    sha256: da89281959d48c60ce546dd370ef712ec1e24714e1e9afadad17dd2fbbc5876e
+    sha256: a32da32a0ea420b8397a53e4b40ed279c1a5fc791dd492a2ced81ffb14ad0d1b
     patches:
         # have to add additional ${PREFIX}/lib etc... to tests/Makefile
         - make_tests.patch  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.800.1" %}
+{% set version = "7.950.0" %}
 {% set variant = "openblas" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
     fn: armadillo-{{ version }}.tar.xz
     url: http://sourceforge.net/projects/arma/files/armadillo-{{ version }}.tar.xz
-    sha256: 5ada65a5a610301ae188bb34f0ac6e7fdafbdbcd0450b0adb7715349ae14b8db
+    sha256: da89281959d48c60ce546dd370ef712ec1e24714e1e9afadad17dd2fbbc5876e
     patches:
         # have to add additional ${PREFIX}/lib etc... to tests/Makefile
         - make_tests.patch  # [linux]
@@ -18,7 +18,7 @@ source:
         - CMakeLists.patch
 
 build:
-  number: 200
+  number: 0
   skip: True  # [win]
   features:
     - blas_{{ variant }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
         - CMakeLists.patch
 
 build:
-  number: 0
+  number: 200
   skip: True  # [win]
   features:
     - blas_{{ variant }}
@@ -56,3 +56,4 @@ about:
 extra:
     recipe-maintainers:
       - grlee77
+      - dirmeier


### PR DESCRIPTION
Minor modifications to the cmake and test patches. Seems to use openblas on macos.